### PR TITLE
Resets CurrentTurn on game reset

### DIFF
--- a/Client/Shared/GameState.cs
+++ b/Client/Shared/GameState.cs
@@ -170,7 +170,8 @@ public class GameState
 	public void ResetBoard() {
 		TheBoard = new List<byte>(new byte[42]);
 		PlayerTurn = 1;
-	}
+		CurrentTurn = 0;
+    }
 
 	public byte ConvertLandingSpotToRow(byte landingSpot)
 	{


### PR DESCRIPTION
Resets CurrentTurn on game reset.  This prevents an array out of bounds exception in PieceClasses array after a few back to back games